### PR TITLE
Cleanup install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,49 @@
 # DefaultDynamic for [Spicetify](https://github.com/khanhas/spicetify-cli)
+
 <a href="https://github.com/JulienMaille/spicetify-dynamic-theme/releases/latest"><img src="https://img.shields.io/github/release/JulienMaille/spicetify-dynamic-theme/all.svg"></a>
 
 This is a tweaked version of the Default theme.
-The main differences are the light/dark toggle, the background cover and the dynamic highligh color, ie. it will match the current album art.
+The main differences are the light/dark toggle, the background cover and the dynamic highlight color, ie. it will match the current album art.
 
 ## Preview
+
 ![demo-base](./Dark.gif)
 
 ## Install / Update
-Make sure you are using spicetify >= v2.6.0 and Spotify >= v1.1.67.
+
+Make sure you are using Spicetify >= v2.6.0 and Spotify >= v1.1.67.
 
 ### Windows (PowerShell)
+
 ```powershell
 Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/master/install.ps1" | Invoke-Expression
 ```
 
 ### Linux/MacOS (Bash)
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/master/install.sh | sh
 ```
 
 ### Manual Install
+
 1. Download the latest [Source code (zip)](https://github.com/JulienMaille/spicetify-dynamic-theme/releases/latest)
 2. Extract the files to your [Spicetify/Themes folder](https://github.com/khanhas/spicetify-cli/wiki/Customization#themes) (rename the zipped folder to `DefaultDynamic`)
 3. Copy `default-dynamic.js` to your [Spicetify/Extensions folder](https://github.com/khanhas/spicetify-cli/wiki/Extensions#installing)
 4. Add the 2 lines in `[Patch]` section of the config file (see details below)
 5. Run:
-     ```
-     spicetify config extensions default-dynamic.js extensions Vibrant.min.js
-     spicetify config current_theme DefaultDynamic
-     spicetify config color_scheme base
-     spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
-     spicetify apply
-     ```
+    ```
+    spicetify config extensions default-dynamic.js extensions Vibrant.min.js
+    spicetify config current_theme DefaultDynamic
+    spicetify config color_scheme base
+    spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
+    spicetify apply
+    ```
 
 ## IMPORTANT!
+
 From Spotify > v1.1.62, in sidebar, they use an adaptive render mechanic to actively show and hide items on scroll. It helps reducing number of items to render, hence there is significant performance boost if you have a large playlists collection. But the drawbacks is that item height is hard-coded, it messes up user interaction when we explicitly change, in CSS, playlist item height bigger than original value. So you need to add these 2 lines in Patch section in config file:
+
 ```ini
 [Patch]
 xpui.js_find_8008 = ,(\w+=)32,
@@ -43,32 +51,39 @@ xpui.js_repl_8008 = ,${1}28,
 ```
 
 ## Follow system dark/light theme (PowerShell)
+
 Automatic dark mode should work on MacOs and Linux out of the box.
 From Spotify > v1.1.70, dark mode is forced in Windows builds. You will need to patch Spotify.exe using this script:
+
 ```powershell
 Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/master/patch-dark-mode.ps1" | Invoke-Expression
 ```
 
 ## Hide Window Controls:
+
 Windows user, please edit your Spotify shortcut and add flag `--transparent-window-controls` after the Spotify.exe
 
 ![hide-controls](./windows-shortcut-instruction.png)
 
 ## Uninstall
+
 ### Windows (PowerShell)
+
 ```powershell
 Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/master/uninstall.ps1" | Invoke-Expression
 ```
 
 ### Linux/MacOS (Bash)
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/master/uninstall.sh | sh
 ```
 
 ### Manual Uninstall
+
 1. Remove Patch lines you added in config file earlier.
 2. Run:
     ```
-    spicetify config current_theme " " extensions default-dynamic.js- extensions Vibrant.min.js-
+    spicetify config current_theme " " color_scheme " " extensions default-dynamic.js- extensions Vibrant.min.js-
     spicetify apply
     ```

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ xpui.js_repl_8008 = ,\${1}28,'
 cd "$(dirname "$(spicetify -c)")"
 if cat config-xpui.ini | grep -o '\[Patch\]'; then
     while true; do
-        read -p "Existing Spicetify patches will be overridden. Do you wish to continue? [y/n] " yn </dev/tty
+        read -p "Existing Spicetify patches will be overwritten. Do you wish to continue? [y/n] " yn </dev/tty
         case $yn in
         [Yy]*) break ;;
         [Nn]*) exit ;;

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,6 @@ if cat config-xpui.ini | grep -o '\[Patch\]'; then
     perl -i -0777 -pe "s/\[Patch\].*?($|(\r*\n){2})/${PATCH}\n\n/s" config-xpui.ini
 else
     echo "\n${PATCH}" >>config-xpui.ini
-    echo "else"
 fi
 
 echo "Finding lastest version (2/4)"

--- a/install.sh
+++ b/install.sh
@@ -1,70 +1,61 @@
 #!/bin/sh
-# Copyright 2019 khanhas. GPL license.
-# Edited from project Denoland install script (https://github.com/denoland/deno_install)
 
 set -e
 
+echo "Patching (1/4)"
+PATCH='[Patch]
+xpui.js_find_8008 = ,(\\w+=)32,
+xpui.js_repl_8008 = ,\${1}28,'
+cd "$(dirname "$(spicetify -c)")"
+if cat config-xpui.ini | grep -o '\[Patch\]'; then
+    while true; do
+        read -p "Existing Spicetify patches will be overridden. Do you wish to continue? [y/n] " yn
+        case $yn in
+        [Yy]*) break ;;
+        [Nn]*) exit ;;
+        *) echo "Please answer yes or no." ;;
+        esac
+    done
+
+    perl -i -0777 -pe "s/\[Patch\].*?($|(\r*\n){2})/${PATCH}\n\n/s" config-xpui.ini
+else
+    echo "\n${PATCH}" >>config-xpui.ini
+    echo "else"
+fi
+
+echo "Finding lastest version (2/4)"
 if [ $# -eq 0 ]; then
     latest_release_uri="https://api.github.com/repos/JulienMaille/spicetify-dynamic-theme/releases/latest"
-    echo "DOWNLOADING    $latest_release_uri"
-    version=$( command curl -sSf "$latest_release_uri" |
+    version=$(command curl -sSf "$latest_release_uri" |
         command grep -Eo "tag_name\": .*" |
-        command grep -Eo "[0-9.]+" )
-    if [ ! "$version" ]; then exit 1; fi
+        command grep -Eo "[0-9.]+")
+    if [ ! "${version}" ]; then exit 1; fi
 else
     version="${1}"
 fi
 
-download_uri="https://github.com/JulienMaille/spicetify-dynamic-theme/archive/refs/tags/${version}.zip"
+echo "Downloading v${version} (3/4)"
+# Setup directories to download to
+theme_dir="$(dirname "$(spicetify -c)")/Themes/DefaultDynamic"
+ext_dir="$(dirname "$(spicetify -c)")/Extensions"
 
-spicetify_install="${SPICETIFY_INSTALL:-$HOME/spicetify-cli/Themes}"
+# Make directories if needed
+mkdir -p "${theme_dir}/assets/glue-resources/fonts"
+mkdir -p "${ext_dir}"
 
-if [ ! -d "$spicetify_install" ]; then
-    echo "MAKING FOLDER  $spicetify_install";
-    mkdir -p "$spicetify_install"
-fi
+# Download latest tagged files into correct directories
+curl --progress-bar --output "${theme_dir}/color.ini" "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/${version}/color.ini"
+curl --progress-bar --output "${theme_dir}/user.css" "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/${version}/user.css"
+curl --progress-bar --output "${theme_dir}/assets/glue-resources/fonts/jost-v6-latin_cyrillic-500.woff2" "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/${version}/assets/glue-resources/fonts/jost-v6-latin_cyrillic-500.woff2"
+curl --progress-bar --output "${theme_dir}/assets/glue-resources/fonts/jost-v6-latin_cyrillic-regular.woff2" "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/${version}/assets/glue-resources/fonts/jost-v6-latin_cyrillic-regular.woff2"
+curl --progress-bar --output "${ext_dir}/default-dynamic.js" "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/${version}/default-dynamic.js"
+curl --progress-bar --output "${ext_dir}/Vibrant.min.js" "https://raw.githubusercontent.com/JulienMaille/spicetify-dynamic-theme/${version}/Vibrant.min.js"
 
-tar_file="$spicetify_install/${version}.zip"
-
-echo "DOWNLOADING    v$version  $download_uri"
-curl --fail --location --progress-bar --output "$tar_file" "$download_uri"
-cd "$spicetify_install"
-
-echo "EXTRACTING     $tar_file"
-unzip "$tar_file"
-
-echo "REMOVING       $tar_file"
-rm "$tar_file"
-
-# Check ~\.spicetify.\Themes directory already exists
-sp_dot_dir="$(dirname "$(spicetify -c)")/Themes/DefaultDynamic"
-if [ ! -d "$sp_dot_dir" ]; then
-    echo "MAKING FOLDER  $sp_dot_dir";
-    mkdir -p "$sp_dot_dir"
-fi
-
-echo "COPYING"
-cp -rf "$spicetify_install/spicetify-dynamic-theme-${version}/." "$sp_dot_dir"
-
-echo "INSTALLING"
-cd "$(dirname "$(spicetify -c)")/Themes/DefaultDynamic"
-mkdir -p ../../Extensions
-cp default-dynamic.js ../../Extensions/.
-cp Vibrant.min.js ../../Extensions/.
+echo "Applying theme (4/4)"
 spicetify config extensions dribbblish.js- extensions dribbblish-dynamic.js-
 spicetify config extensions default-dynamic.js extensions Vibrant.min.js
 spicetify config current_theme DefaultDynamic color_scheme base
 spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
-
-echo "PATCHING"
-PATCH='[Patch]
-xpui.js_find_8008 = ,(\\w+=)32,
-xpui.js_repl_8008 = ,\${1}28,'
-if cat config-xpui.ini | grep -o '\[Patch\]'; then
-    perl -i -0777 -pe "s/\[Patch\].*?($|(\r*\n){2})/$PATCH\n\n/s" config-xpui.ini
-else
-    echo -e "\n$PATCH" >> config-xpui.ini
-fi
-
-echo "APPLYING"
 spicetify apply
+
+echo "All done!"

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ xpui.js_repl_8008 = ,\${1}28,'
 cd "$(dirname "$(spicetify -c)")"
 if cat config-xpui.ini | grep -o '\[Patch\]'; then
     while true; do
-        read -p "Existing Spicetify patches will be overridden. Do you wish to continue? [y/n] " yn
+        read -p "Existing Spicetify patches will be overridden. Do you wish to continue? [y/n] " yn </dev/tty
         case $yn in
         [Yy]*) break ;;
         [Nn]*) exit ;;

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$(spicetify -c)")"
 echo "Unpatching (1/3)"
 if cat config-xpui.ini | grep -o '\[Patch\]'; then
     while true; do
-        read -p "All Spicetify custom patches will be deleted. Is this ok? [y/n] " yn
+        read -p "All Spicetify custom patches will be deleted. Is this ok? [y/n] " yn </dev/tty
         case $yn in
         [Yy]*) break ;;
         [Nn]*) exit ;;
@@ -23,7 +23,7 @@ spicetify config current_theme "SpicetifyDefault" color_scheme "green-dark" exte
 
 echo "Deleting (3/3)"
 while true; do
-    read -p "Do you wish to delete theme files? [y/n] " yn
+    read -p "Do you wish to delete theme files? [y/n] " yn </dev/tty
     case $yn in
     [Yy]*)
         theme_dir="$(dirname "$(spicetify -c)")/Themes/DefaultDynamic"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,16 +1,45 @@
 #!/bin/sh
-# Copyright 2019 khanhas. GPL license.
-# Edited from project Denoland install script (https://github.com/denoland/deno_install)
 
 set -e
 
-echo "UN-INSTALLING"
 cd "$(dirname "$(spicetify -c)")"
-spicetify config current_theme "SpicetifyDefault" extensions default-dynamic.js-
 
-echo "UN-PATCHING"
+echo "Unpatching (1/3)"
 if cat config-xpui.ini | grep -o '\[Patch\]'; then
+    while true; do
+        read -p "All Spicetify custom patches will be deleted. Is this ok? [y/n] " yn
+        case $yn in
+        [Yy]*) break ;;
+        [Nn]*) exit ;;
+        *) echo "Please answer yes or no." ;;
+        esac
+    done
     perl -i -0777 -pe "s/\[Patch\].*?($|(\r*\n){2})//s" config-xpui.ini
 fi
+
+echo "Uninstalling (2/3)"
+cd "$(dirname "$(spicetify -c)")"
+spicetify config current_theme "SpicetifyDefault" color_scheme "green-dark" extensions default-dynamic.js- extensions Vibrant.min.js-
+
+echo "Deleting (3/3)"
+while true; do
+    read -p "Do you wish to delete theme files? [y/n] " yn
+    case $yn in
+    [Yy]*)
+        theme_dir="$(dirname "$(spicetify -c)")/Themes/DefaultDynamic"
+        ext_dir="$(dirname "$(spicetify -c)")/Extensions"
+        rm -rf "$theme_dir"
+        # Use -f to ignore if missing
+        rm -f "$ext_dir/default-dynamic.js"
+        rm -f "$ext_dir/Vibrant.min.js"
+        break
+        ;;
+    [Nn]*)
+        echo "Skipping deletion."
+        break
+        ;;
+    *) echo "Please answer yes or no." ;;
+    esac
+done
 
 spicetify apply


### PR DESCRIPTION
This offers a few benefits

- Doesn't download entire repo and leave it in multiple places
- Supports reinstalling/updating
- Removes unsupported flags such as `echo -e`
- Explicit warning about removing potentially useful patches

Similar changes have also been applied to uninstall.sh to make it more robust and also to add an option to delete all dynamic theme files on uninstall.
