### PR TITLE
POSIX sed compliancy

### DIFF
--- a/patch-dark-mode.sh
+++ b/patch-dark-mode.sh
@@ -30,6 +30,6 @@ if [[ ! -f "$path" ]]; then
 fi
 
 # Patch the binary
-sed -i.bak 's/force-dark-mode/xxxxx-xxxx-xxxx/' "$path"
+sed -i.bak 's/force-dark-mode/donot-dark-mode/' "$path"
 
 echo "The patch is complete. You may now restart Spotify."


### PR DESCRIPTION
GNU sed supports `\x` while BSD sed doesn't. Replacing the flag with null bytes isn't needed as making it invalid is enough to get dark mode detection working.

closes #102